### PR TITLE
PHP CS Fixer v3.57.2

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -6,6 +6,7 @@ name: Create and publish a Docker image
 on:
   push:
     branches: ['*']
+  pull_request:
 
 jobs:
   checks-update:

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -67,21 +67,25 @@ jobs:
       packages: write
     strategy:
       matrix:
-        version: ['1','2.19','2','3.12','3.13', '3']
+        # Update only v3 images without touching older ones to better manage back-compatibility
+        version: ['3.12', '3.13', '3.57', '3']
     needs: [checks-hadolint, checks-shfmt, checks-shellcheck, checks-update]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
         if: github.ref == 'refs/heads/main'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -94,9 +98,11 @@ jobs:
             latest=${{ toJSON(matrix.version == '3' && github.ref == 'refs/heads/main') }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: ${{ matrix.version }}
+          # Build for Linux and Apple Silicon processors
+          platforms: linux/amd64,linux/arm64,linux/arm64/v8
           push: ${{ github.ref == 'refs/heads/main' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/3.57/Dockerfile
+++ b/3.57/Dockerfile
@@ -1,6 +1,6 @@
-FROM php:8.2-alpine
+FROM php:8.3-alpine
 
-ENV PHP_CS_FIXER_VERSION 3.17.0
+ENV PHP_CS_FIXER_VERSION 3.57.2
 # hadolint ignore=DL3018
 RUN curl -L https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v$PHP_CS_FIXER_VERSION/php-cs-fixer.phar -o php-cs-fixer \
     && chmod +x php-cs-fixer \

--- a/3/Dockerfile
+++ b/3/Dockerfile
@@ -1,6 +1,6 @@
-FROM php:8.0-alpine
+FROM php:8.3-alpine
 
-ENV PHP_CS_FIXER_VERSION 3.13.2
+ENV PHP_CS_FIXER_VERSION 3.57.2
 # hadolint ignore=DL3018
 RUN curl -L https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v$PHP_CS_FIXER_VERSION/php-cs-fixer.phar -o php-cs-fixer \
     && chmod +x php-cs-fixer \

--- a/update.sh
+++ b/update.sh
@@ -3,23 +3,25 @@ set -e
 
 # https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases
 declare -A variants=(
-  ['3.17']='3.17.0'
-  ['3']='3.13.2'
+  ['3']='3.57.2'
+  ['3.57']='3.57.2'
   ['3.13']='3.13.2'
   ['3.12']='3.12.0'
-  ['2']='2.19.3'
-  ['2.19']='2.19.3'
-  ['1']='1.13.3'
+  # Don't rebuild old images
+  # ['2']='2.19.3'
+  # ['2.19']='2.19.3'
+  # ['1']='1.13.3'
 )
 
 declare -A php_version=(
-  ['3.17']='8.2'
-  ['3']='8.0'
+  ['3']='8.3'
+  ['3.57']='8.3'
   ['3.13']='8.1'
   ['3.12']='8.1'
-  ['2']='8.0'
-  ['2.19']='8.0'
-  ['1']='7.1'
+  # Don't rebuild old images
+  # ['2']='8.0'
+  # ['2.19']='8.0'
+  # ['1']='7.1'
 )
 
 for variant in "${!variants[@]}"; do
@@ -39,5 +41,5 @@ for variant in "${!variants[@]}"; do
     '"$extraSed"'
     s/%%VARIANT%%/'"${variants[$variant]}"'/;
     s/%%PHP_VERSION%%/'"${php_version[$variant]}"'/;
-  ' $template >"$dir/Dockerfile"
+  ' "$template" >"$dir/Dockerfile"
 done


### PR DESCRIPTION
- PHP CS Fixer v3.57.2
- Remove v3.17 image as it has never been released
- Don't rebuild old images (v1 and v2)
- Apple Silicon build for local development